### PR TITLE
feat: strip internals

### DIFF
--- a/src/geo-map.ts
+++ b/src/geo-map.ts
@@ -10,6 +10,10 @@ import { GeoMapPlacesService } from './geo-map-places-service';
 
 export class GeoMap {
   public readonly provider: Types.GeoMapProvider;
+
+  /**
+   * @internal
+   */
   private implementation: Types.GeoMapImplementation;
 
   public static create(init: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "pretty": true,
     "sourceMap": true,
     "declaration": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "stripInternal": true
   },
   "include": [
     "./src/**/*.ts",


### PR DESCRIPTION
To remove internal apis from created defintions files we
flag them as internal and let the compiler strip this
definitions.